### PR TITLE
「戻る」リンクの改善

### DIFF
--- a/components/Logo.js
+++ b/components/Logo.js
@@ -2,7 +2,7 @@ import Image from 'next/image';
 
 function Logo(props) {
   return (
-    <div id="logo">
+    <header id="logo">
       <a href="https://waic.jp/">
         <Image
           src="https://waic.jp/wp-content/themes/waic/images/header_logo.png"
@@ -11,7 +11,7 @@ function Logo(props) {
           width={314} height={72}
         />
       </a>
-    </div>
+    </header>
   )
 }
 export default Logo;

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -1,7 +1,7 @@
 import Document, { Html, Head, Main, NextScript } from 'next/document'
 
 export default class MyDocument extends Document {
-  render () {
+  render() {
     return (
       <Html lang="ja">
         <Head>
@@ -13,8 +13,23 @@ export default class MyDocument extends Document {
           <meta name="keywords" content="ウェブ,アクセシビリティ,基盤,委員会,WAIC,web,accessibility,infrastructure,committee,アクセシビリティ,サポーテッド,AS,情報" />
           <meta name="description" content="アクセシビリティ サポーテッド（AS）情報に関する解説文書" />
           <link rel="stylesheet" type="text/css" href="https://waic.jp/cmn/css/docs.css" />
-          <style type="text/css" dangerouslySetInnerHTML={{__html: "table{empty-cells: show;}tr.warn{background: #ffd;}tr.ng{background: #fdd;}" }} />
-          <style type="text/css" dangerouslySetInnerHTML={{__html: "hr{display: block !important; margin: 2em 0 2em 0;}" }} />
+          <style>
+            {`
+            table {
+              empty-cells: show;
+            }
+            tr.warn {
+              background: #ffd;
+            }
+            tr.ng {
+                background: #fdd;
+            }
+            hr {
+              display: block !important;
+              margin: 2em 0 2em 0;
+            }
+            `}
+          </style>
         </Head>
         <body>
           <Main />

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -14,6 +14,7 @@ export default class MyDocument extends Document {
           <meta name="description" content="アクセシビリティ サポーテッド（AS）情報に関する解説文書" />
           <link rel="stylesheet" type="text/css" href="https://waic.jp/cmn/css/docs.css" />
           <style type="text/css" dangerouslySetInnerHTML={{__html: "table{empty-cells: show;}tr.warn{background: #ffd;}tr.ng{background: #fdd;}" }} />
+          <style type="text/css" dangerouslySetInnerHTML={{__html: "hr{display: block !important; margin: 2em 0 2em 0;}" }} />
         </Head>
         <body>
           <Main />

--- a/pages/criteria/[id].js
+++ b/pages/criteria/[id].js
@@ -18,27 +18,29 @@ const Criterion = ({ query }) => {
     <>
       <NextSeo {...Object.assign(SEO, { title: '達成基準' + true_id })} />
       <Logo />
-      <H1
-        first='アクセシビリティ サポーテッド（AS）情報：達成基準'
-        second={`${true_id} ${criterion.title} (レベル ${criterion.level})`}
-      />
-      <ul>
-        <li>作成者：{metadata.author}</li>
-        <li><a href="../">アクセシビリティ サポーテッド（AS）情報のホームへ</a></li>
-      </ul>
-      <h2>検証結果を含む達成方法</h2>
-      <ul>
-        {queryTechs(true_id).map(tech_id => {
-          const tech = techs[tech_id];
-          return (
-            <li key={tech_id}>
-              {tech ? (
-                <a href={'../techs/' + tech_id + '.html'}>{tech_id}: {tech.title}</a>
-              ) : tech_id}
-            </li>
-          );
-        })}
-      </ul>
+      <main>
+        <H1
+          first='アクセシビリティ サポーテッド（AS）情報：達成基準'
+          second={`${true_id} ${criterion.title} (レベル ${criterion.level})`}
+        />
+        <ul>
+          <li>作成者：{metadata.author}</li>
+          <li><a href="../">アクセシビリティ サポーテッド（AS）情報のホームへ</a></li>
+        </ul>
+        <h2>検証結果を含む達成方法</h2>
+        <ul>
+          {queryTechs(true_id).map(tech_id => {
+            const tech = techs[tech_id];
+            return (
+              <li key={tech_id}>
+                {tech ? (
+                  <a href={'../techs/' + tech_id + '.html'}>{tech_id}: {tech.title}</a>
+                ) : tech_id}
+              </li>
+            );
+          })}
+        </ul>
+      </main>
     </>
   )
 }

--- a/pages/criteria/[id].js
+++ b/pages/criteria/[id].js
@@ -24,7 +24,7 @@ const Criterion = ({ query }) => {
       />
       <ul>
         <li>作成者：{metadata.author}</li>
-        <li><a href="../">アクセシビリティ サポーテッド（AS）情報のインデクスに戻る</a></li>
+        <li><a href="../">アクセシビリティ サポーテッド（AS）情報のホームへ</a></li>
       </ul>
       <h2>検証結果を含む達成方法</h2>
       <ul>

--- a/pages/criteria/[id].js
+++ b/pages/criteria/[id].js
@@ -24,7 +24,7 @@ const Criterion = ({ query }) => {
       />
       <ul>
         <li>作成者：{metadata.author}</li>
-        <li><a href="../">戻る</a></li>
+        <li><a href="../">アクセシビリティ サポーテッド（AS）情報のインデクスに戻る</a></li>
       </ul>
       <h2>検証結果を含む達成方法</h2>
       <ul>

--- a/pages/criteria/[id].js
+++ b/pages/criteria/[id].js
@@ -25,7 +25,6 @@ const Criterion = ({ query }) => {
         />
         <ul>
           <li>作成者：{metadata.author}</li>
-          <li><a href="../">アクセシビリティ サポーテッド（AS）情報のホームへ</a></li>
         </ul>
         <h2>検証結果を含む達成方法</h2>
         <ul>
@@ -39,6 +38,10 @@ const Criterion = ({ query }) => {
               </li>
             );
           })}
+        </ul>
+        <hr />
+        <ul>
+          <li><a href="../">アクセシビリティ サポーテッド（AS）情報のホームへ</a></li>
         </ul>
       </main>
     </>

--- a/pages/index.js
+++ b/pages/index.js
@@ -6,33 +6,35 @@ import criteria from '../data/criteria.yaml'
 import { NextSeo } from 'next-seo'
 import SEO from '../next-seo.config'
 
-const Index = () => 
-<>
-  <NextSeo {...Object.assign(SEO, {title:'ホーム'})}/>
-  <Logo/>
-  <h1>アクセシビリティ サポーテッド（AS）情報</h1>
-  <ul>
-    <li>公開日：{metadata.pub_date}</li>
-    <li>更新日：{metadata.mod_date}</li>
-    <li>作成者：{metadata.author}</li>
-    <li><a href="https://waic.jp/guideline/as/#past_results">過去のアクセシビリティ サポーテッド検証結果</a></li>
-  </ul>
-  <h2>検証結果を含む達成基準</h2>
-  <ul>
-    {Object.keys(criteria).map(
-      key => <li key={key}>
-        <a href={'criteria/' + key + '.html'}>{key} {criteria[key].title}</a>
-      </li>
-    )}
-  </ul>
-  <h2>テストの一覧</h2>
-  <ul>
-    {Object.keys(tests).map(
-      key => <li key={key}>
-        <a href={'results/' + key + '.html'}>{key}: {tests[key].title}</a>
-      </li>
-    )}
-  </ul>
-</>
+const Index = () =>
+  <>
+    <NextSeo {...Object.assign(SEO, { title: 'ホーム' })} />
+    <Logo />
+    <main>
+      <h1>アクセシビリティ サポーテッド（AS）情報</h1>
+      <ul>
+        <li>公開日：{metadata.pub_date}</li>
+        <li>更新日：{metadata.mod_date}</li>
+        <li>作成者：{metadata.author}</li>
+        <li><a href="https://waic.jp/guideline/as/#past_results">過去のアクセシビリティ サポーテッド検証結果</a></li>
+      </ul>
+      <h2>検証結果を含む達成基準</h2>
+      <ul>
+        {Object.keys(criteria).map(
+          key => <li key={key}>
+            <a href={'criteria/' + key + '.html'}>{key} {criteria[key].title}</a>
+          </li>
+        )}
+      </ul>
+      <h2>テストの一覧</h2>
+      <ul>
+        {Object.keys(tests).map(
+          key => <li key={key}>
+            <a href={'results/' + key + '.html'}>{key}: {tests[key].title}</a>
+          </li>
+        )}
+      </ul>
+    </main>
+  </>
 
 export default Index;

--- a/pages/results/[id].js
+++ b/pages/results/[id].js
@@ -161,7 +161,7 @@ const Result = ({ query }) => {
       />
       <ul>
         <li>作成者：{metadata.author}</li>
-        <li><a href="../">アクセシビリティ サポーテッド（AS）情報のインデクスに戻る</a></li>
+        <li><a href="../">アクセシビリティ サポーテッド（AS）情報のホームへ</a></li>
       </ul>
       <h2>テストの対象となる達成基準</h2>
       <ul>

--- a/pages/results/[id].js
+++ b/pages/results/[id].js
@@ -161,7 +161,7 @@ const Result = ({ query }) => {
       />
       <ul>
         <li>作成者：{metadata.author}</li>
-        <li><a href="../">戻る</a></li>
+        <li><a href="../">アクセシビリティ サポーテッド（AS）情報のインデクスに戻る</a></li>
       </ul>
       <h2>テストの対象となる達成基準</h2>
       <ul>

--- a/pages/results/[id].js
+++ b/pages/results/[id].js
@@ -57,62 +57,62 @@ const ResultTableRow = (props) => {
   const contents = result.contents;
   if (contents.length === 1) {
     return (
-    <tr>
-      <th scope="row">{result.id}</th>
-      <td style={larger_th_style}><ul>
-        <li style={list_item_style}>{result.os}</li>
-        <li style={list_item_style}>{result.user_agent}</li>
-        {result.assistive_tech && (<li style={list_item_style}>{result.assistive_tech}</li>)}
-        {result.assistive_tech_config && (<li style={list_item_style}>{nl2br(result.assistive_tech_config)}</li>)}
-      </ul></td>
-      <td>
-        {contents[0].judgment === '満たしている' ? '○' : '×'}
-      </td>
-      <td style={larger_th_style}>
-        {nl2br(contents[0].procedure)}
-      </td>
-      <td style={larger_th_style}>
-        {nl2br(contents[0].actual)}
-      </td>
-      <td style={larger_th_style}>{getTesterName(result)}</td>
-      <td style={larger_th_style}>{getDate(result)}</td>
-      <td style={larger_th_style}><Comment result={result}/></td>
-    </tr>
+      <tr>
+        <th scope="row">{result.id}</th>
+        <td style={larger_th_style}><ul>
+          <li style={list_item_style}>{result.os}</li>
+          <li style={list_item_style}>{result.user_agent}</li>
+          {result.assistive_tech && (<li style={list_item_style}>{result.assistive_tech}</li>)}
+          {result.assistive_tech_config && (<li style={list_item_style}>{nl2br(result.assistive_tech_config)}</li>)}
+        </ul></td>
+        <td>
+          {contents[0].judgment === '満たしている' ? '○' : '×'}
+        </td>
+        <td style={larger_th_style}>
+          {nl2br(contents[0].procedure)}
+        </td>
+        <td style={larger_th_style}>
+          {nl2br(contents[0].actual)}
+        </td>
+        <td style={larger_th_style}>{getTesterName(result)}</td>
+        <td style={larger_th_style}>{getDate(result)}</td>
+        <td style={larger_th_style}><Comment result={result} /></td>
+      </tr>
     );
   }
   return (
     <>
-    {contents.map((item, index) => (
-      <tr key={index}>
-        {index === 0 && (
-          <>
-            <th rowSpan={contents.length} scope="rowgroup">{result.id}</th>
-            <td rowSpan={contents.length} style={larger_th_style}><ul>
-              <li style={list_item_style}>{result.os}</li>
-              <li style={list_item_style}>{result.user_agent}</li>
-              {result.assistive_tech && (<li style={list_item_style}>{result.assistive_tech}</li>)}
-              {result.assistive_tech_config && (<li style={list_item_style}>{nl2br(result.assistive_tech_config)}</li>)}
-            </ul></td>
-          </>
-        )}
-        <td>
-          {item.judgment === '満たしている' ? '○' : '×'}
-        </td>
-        <td style={larger_th_style}>
-          {nl2br(item.procedure)}
-        </td>
-        <td style={larger_th_style}>
-          {nl2br(item.actual)}
-        </td>
-        {index === 0 && (
-          <>
-          <td rowSpan={contents.length} style={larger_th_style}>{getTesterName(result)}</td>
-          <td rowSpan={contents.length} style={larger_th_style}>{getDate(result)}</td>
-          <td rowSpan={contents.length} style={larger_th_style}><Comment result={result}/></td>
-          </>
-        )}
-      </tr>
-    ))}
+      {contents.map((item, index) => (
+        <tr key={index}>
+          {index === 0 && (
+            <>
+              <th rowSpan={contents.length} scope="rowgroup">{result.id}</th>
+              <td rowSpan={contents.length} style={larger_th_style}><ul>
+                <li style={list_item_style}>{result.os}</li>
+                <li style={list_item_style}>{result.user_agent}</li>
+                {result.assistive_tech && (<li style={list_item_style}>{result.assistive_tech}</li>)}
+                {result.assistive_tech_config && (<li style={list_item_style}>{nl2br(result.assistive_tech_config)}</li>)}
+              </ul></td>
+            </>
+          )}
+          <td>
+            {item.judgment === '満たしている' ? '○' : '×'}
+          </td>
+          <td style={larger_th_style}>
+            {nl2br(item.procedure)}
+          </td>
+          <td style={larger_th_style}>
+            {nl2br(item.actual)}
+          </td>
+          {index === 0 && (
+            <>
+              <td rowSpan={contents.length} style={larger_th_style}>{getTesterName(result)}</td>
+              <td rowSpan={contents.length} style={larger_th_style}>{getDate(result)}</td>
+              <td rowSpan={contents.length} style={larger_th_style}><Comment result={result} /></td>
+            </>
+          )}
+        </tr>
+      ))}
     </>
   )
 };
@@ -120,7 +120,7 @@ const ResultTableRow = (props) => {
 const Result = ({ query }) => {
   const router = useRouter()
   const { id } = router.query
-  const true_id = id.replace(/.html$/,'') // '.html' is appended to the routing path when exporting, so remove it.
+  const true_id = id.replace(/.html$/, '') // '.html' is appended to the routing path when exporting, so remove it.
   const test = tests[true_id];
   const criterion_ids = test.criteria;
   const tech_ids = test.techs;
@@ -142,77 +142,79 @@ const Result = ({ query }) => {
   } else {
     test_code_elem = (
       <>
-      <div>テストコード {true_id} をユーザーエージェントで表示</div>
+        <div>テストコード {true_id} をユーザーエージェントで表示</div>
         <ul>
-        {test.code.map((item, index) => (
-          <li key={index}><a href={item}>{item.split("/").slice(-1)[0]}</a></li>
-        ))}
+          {test.code.map((item, index) => (
+            <li key={index}><a href={item}>{item.split("/").slice(-1)[0]}</a></li>
+          ))}
         </ul>
       </>
     );
   }
   return (
     <>
-      <NextSeo {...Object.assign(SEO, {title:'テスト' + true_id})}/>
-      <Logo/>
-      <H1
-        first='アクセシビリティ サポーテッド (AS) 情報：テストケース'
-        second={`${true_id}: ${test.title}`}
-      />
-      <ul>
-        <li>作成者：{metadata.author}</li>
-        <li><a href="../">アクセシビリティ サポーテッド（AS）情報のホームへ</a></li>
-      </ul>
-      <h2>テストの対象となる達成基準</h2>
-      <ul>
-        {criterion_ids.map(criterion_id => (
-        <li key={criterion_id}>
-          <a href={'../criteria/' + criterion_id + '.html'}>{criterion_id} {criteria[criterion_id].title} (レベル{criteria[criterion_id].level}) に関連するAS情報</a>
-        </li>
-        ))}
-      </ul>
-      <h2>関連する達成方法</h2>
-      <ul>
-        {tech_ids.map(tech_id => (
-        <li key={tech_id}>
-          <a href={'../techs/' + tech_id + '.html'}>{tech_id}:「{techs[tech_id].title}」に関連するAS情報</a>
-        </li>
-        ))}
-      </ul>
-      <h2>テスト詳細</h2>
-      <ul>
-        <li><a href={test.document}>テストケース {true_id} の詳細を表示</a></li>
-        <li>{test_code_elem}</li>
-      </ul>
-      <h2>検証結果一覧</h2>
-      <ul>
-        <li>テスト結果の件数: {result_ids.length}件</li>
-      </ul>
-      {result_ids.length > 0 && (<>
-      <h3>テスト結果の詳細</h3>
-      <table>
-        <thead>
-          <tr>
-            <th scope="col">ID</th>
-            <th scope="col">環境</th>
-            <th scope="col">判断</th>
-            <th scope="col">操作内容</th>
-            <th scope="col">得られた結果</th>
-            <th scope="col">テスト実施者</th>
-            <th scope="col">実施日</th>
-            <th scope="col">備考</th>
-          </tr>
-        </thead>
-        <tbody>
-          {result_ids.map((result, index) => (
-            <ResultTableRow result={result} index={index} key={index}/>
+      <NextSeo {...Object.assign(SEO, { title: 'テスト' + true_id })} />
+      <Logo />
+      <main>
+        <H1
+          first='アクセシビリティ サポーテッド (AS) 情報：テストケース'
+          second={`${true_id}: ${test.title}`}
+        />
+        <ul>
+          <li>作成者：{metadata.author}</li>
+          <li><a href="../">アクセシビリティ サポーテッド（AS）情報のホームへ</a></li>
+        </ul>
+        <h2>テストの対象となる達成基準</h2>
+        <ul>
+          {criterion_ids.map(criterion_id => (
+            <li key={criterion_id}>
+              <a href={'../criteria/' + criterion_id + '.html'}>{criterion_id} {criteria[criterion_id].title} (レベル{criteria[criterion_id].level}) に関連するAS情報</a>
+            </li>
           ))}
-        </tbody>
-      </table>
-      </>)}
-      <h2>ライセンス</h2>
-      <p>各検証結果は、それぞれの作成者を原著作者とし、クリエイティブ・コモンズ・ライセンスの下でライセンスされています。原著作者名は、それぞれの検証結果をご覧ください。また、ご利用になる前に利用許諾条項を必ずご確認ください。</p>
-      <p><a href="https://creativecommons.org/licenses/by-sa/4.0/deed.ja"><Image src="https://mirrors.creativecommons.org/presskit/buttons/88x31/png/by-sa.png" alt="by-sa" width="88" height="31"/> 利用許諾条項（表示 – 継承 4.0 国際）の確認</a></p>
+        </ul>
+        <h2>関連する達成方法</h2>
+        <ul>
+          {tech_ids.map(tech_id => (
+            <li key={tech_id}>
+              <a href={'../techs/' + tech_id + '.html'}>{tech_id}:「{techs[tech_id].title}」に関連するAS情報</a>
+            </li>
+          ))}
+        </ul>
+        <h2>テスト詳細</h2>
+        <ul>
+          <li><a href={test.document}>テストケース {true_id} の詳細を表示</a></li>
+          <li>{test_code_elem}</li>
+        </ul>
+        <h2>検証結果一覧</h2>
+        <ul>
+          <li>テスト結果の件数: {result_ids.length}件</li>
+        </ul>
+        {result_ids.length > 0 && (<>
+          <h3>テスト結果の詳細</h3>
+          <table>
+            <thead>
+              <tr>
+                <th scope="col">ID</th>
+                <th scope="col">環境</th>
+                <th scope="col">判断</th>
+                <th scope="col">操作内容</th>
+                <th scope="col">得られた結果</th>
+                <th scope="col">テスト実施者</th>
+                <th scope="col">実施日</th>
+                <th scope="col">備考</th>
+              </tr>
+            </thead>
+            <tbody>
+              {result_ids.map((result, index) => (
+                <ResultTableRow result={result} index={index} key={index} />
+              ))}
+            </tbody>
+          </table>
+        </>)}
+        <h2>ライセンス</h2>
+        <p>各検証結果は、それぞれの作成者を原著作者とし、クリエイティブ・コモンズ・ライセンスの下でライセンスされています。原著作者名は、それぞれの検証結果をご覧ください。また、ご利用になる前に利用許諾条項を必ずご確認ください。</p>
+        <p><a href="https://creativecommons.org/licenses/by-sa/4.0/deed.ja"><Image src="https://mirrors.creativecommons.org/presskit/buttons/88x31/png/by-sa.png" alt="by-sa" width="88" height="31" /> 利用許諾条項（表示 – 継承 4.0 国際）の確認</a></p>
+      </main>
     </>
   )
 }

--- a/pages/results/[id].js
+++ b/pages/results/[id].js
@@ -162,7 +162,6 @@ const Result = ({ query }) => {
         />
         <ul>
           <li>作成者：{metadata.author}</li>
-          <li><a href="../">アクセシビリティ サポーテッド（AS）情報のホームへ</a></li>
         </ul>
         <h2>テストの対象となる達成基準</h2>
         <ul>
@@ -214,6 +213,10 @@ const Result = ({ query }) => {
         <h2>ライセンス</h2>
         <p>各検証結果は、それぞれの作成者を原著作者とし、クリエイティブ・コモンズ・ライセンスの下でライセンスされています。原著作者名は、それぞれの検証結果をご覧ください。また、ご利用になる前に利用許諾条項を必ずご確認ください。</p>
         <p><a href="https://creativecommons.org/licenses/by-sa/4.0/deed.ja"><Image src="https://mirrors.creativecommons.org/presskit/buttons/88x31/png/by-sa.png" alt="by-sa" width="88" height="31" /> 利用許諾条項（表示 – 継承 4.0 国際）の確認</a></p>
+        <hr />
+        <ul>
+          <li><a href="../">アクセシビリティ サポーテッド（AS）情報のホームへ</a></li>
+        </ul>
       </main>
     </>
   )

--- a/pages/techs/[id].js
+++ b/pages/techs/[id].js
@@ -30,7 +30,7 @@ const Tech = ({ query }) => {
       />
       <ul>
         <li>作成者：{metadata.author}</li>
-        <li><a href="../">戻る</a></li>
+        <li><a href="../">アクセシビリティ サポーテッド（AS）情報のインデクスに戻る</a></li>
       </ul>
       <h2>テストの対象となる達成基準</h2>
       <ul>

--- a/pages/techs/[id].js
+++ b/pages/techs/[id].js
@@ -30,7 +30,7 @@ const Tech = ({ query }) => {
       />
       <ul>
         <li>作成者：{metadata.author}</li>
-        <li><a href="../">アクセシビリティ サポーテッド（AS）情報のインデクスに戻る</a></li>
+        <li><a href="../">アクセシビリティ サポーテッド（AS）情報のホームへ</a></li>
       </ul>
       <h2>テストの対象となる達成基準</h2>
       <ul>

--- a/pages/techs/[id].js
+++ b/pages/techs/[id].js
@@ -24,30 +24,32 @@ const Tech = ({ query }) => {
     <>
       <NextSeo {...Object.assign(SEO, { title: '達成方法' + true_id })} />
       <Logo />
-      <H1
-        first='アクセシビリティ サポーテッド（AS）情報：達成方法'
-        second={`${true_id}: ${tech.title}`}
-      />
-      <ul>
-        <li>作成者：{metadata.author}</li>
-        <li><a href="../">アクセシビリティ サポーテッド（AS）情報のホームへ</a></li>
-      </ul>
-      <h2>テストの対象となる達成基準</h2>
-      <ul>
-        {criterion_ids.map(criterion_id => (
-          <li key={criterion_id}>
-            <a href={'../criteria/' + criterion_id + '.html'}>{criterion_id} {criteria[criterion_id].title} (レベル{criteria[criterion_id].level})</a>
-          </li>
-        ))}
-      </ul>
-      <h2>検証結果を含むテストケース</h2>
-      <ul>
-        {test_ids.map(test_id => (
-          <li key={test_id}>
-            <a href={'../results/' + test_id + '.html'}>{test_id}: {tests[test_id].title} (結果:{getResultsCount(test_id)}件)</a>
-          </li>
-        ))}
-      </ul>
+      <main>
+        <H1
+          first='アクセシビリティ サポーテッド（AS）情報：達成方法'
+          second={`${true_id}: ${tech.title}`}
+        />
+        <ul>
+          <li>作成者：{metadata.author}</li>
+          <li><a href="../">アクセシビリティ サポーテッド（AS）情報のホームへ</a></li>
+        </ul>
+        <h2>テストの対象となる達成基準</h2>
+        <ul>
+          {criterion_ids.map(criterion_id => (
+            <li key={criterion_id}>
+              <a href={'../criteria/' + criterion_id + '.html'}>{criterion_id} {criteria[criterion_id].title} (レベル{criteria[criterion_id].level})</a>
+            </li>
+          ))}
+        </ul>
+        <h2>検証結果を含むテストケース</h2>
+        <ul>
+          {test_ids.map(test_id => (
+            <li key={test_id}>
+              <a href={'../results/' + test_id + '.html'}>{test_id}: {tests[test_id].title} (結果:{getResultsCount(test_id)}件)</a>
+            </li>
+          ))}
+        </ul>
+      </main>
     </>
   )
 }

--- a/pages/techs/[id].js
+++ b/pages/techs/[id].js
@@ -31,7 +31,6 @@ const Tech = ({ query }) => {
         />
         <ul>
           <li>作成者：{metadata.author}</li>
-          <li><a href="../">アクセシビリティ サポーテッド（AS）情報のホームへ</a></li>
         </ul>
         <h2>テストの対象となる達成基準</h2>
         <ul>
@@ -48,6 +47,10 @@ const Tech = ({ query }) => {
               <a href={'../results/' + test_id + '.html'}>{test_id}: {tests[test_id].title} (結果:{getResultsCount(test_id)}件)</a>
             </li>
           ))}
+        </ul>
+        <hr />
+        <ul>
+          <li><a href="../">アクセシビリティ サポーテッド（AS）情報のホームへ</a></li>
         </ul>
       </main>
     </>


### PR DESCRIPTION
達成方法 テストケース などのページの上の方にある「戻る」というリンクテキストをわかりやすくするため
「アクセシビリティ サポーテッド（AS）情報のインデクスに戻る」
に変更します。