### PR TITLE
feat: テーブルが長細くならないように調整

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -23,8 +23,9 @@ const fullTitle = `${title}：アクセシビリティ サポーテッド（AS�
     <title>{fullTitle}</title>
     <style is:global>
       table {
-        width: 100%;
         empty-cells: show;
+        margin: 0 calc(50% - 40vw);
+        width: 80vw;
       }
       @media (max-width: 600px) {
         table {

--- a/src/pages/results/[id].astro
+++ b/src/pages/results/[id].astro
@@ -79,6 +79,7 @@ function isInReview(resultId: number): boolean {
 
 const largerThStyle = 'min-width: 6em; max-width: 10em; overflow-wrap: break-word;';
 const listItemStyle = 'overflow-wrap: break-word;';
+const actualResultStyle = 'min-width: 400px;';
 ---
 
 <BaseLayout title={`テスト${testId}`}>
@@ -190,7 +191,7 @@ const listItemStyle = 'overflow-wrap: break-word;';
                     <td style={largerThStyle}>
                       {contents[0].procedure?.split('\n').map((line: string) => <p>{line}</p>)}
                     </td>
-                    <td style={largerThStyle}>
+                    <td style={`${largerThStyle} ${actualResultStyle}`}>
                       {contents[0].actual?.split('\n').map((line: string) => <p>{line}</p>)}
                     </td>
                     <td style={largerThStyle}>{getTesterName(result)}</td>


### PR DESCRIPTION
テストケースやテスト結果によっては「得られた結果」の文章が長くなりがちで、セルが長細くなってしまっていたのでテーブル自体の横幅を広げ、spで横スクロールが発生している時も含めて「得られた結果」の列が最低400px確保されるように修正しました。
PC時はメインコンテンツの横幅と合わない表示になっているので、違和感があればPC時は元のままにするか、5枚目に貼った代替案のように、左端はメインコンテンツに合わせて右側のみはみ出させることもできそうです。

PC before
<img width="1920" height="911" alt="「得られた結果」の列が長細くなっている、PC表示時のテーブル" src="https://github.com/user-attachments/assets/8363c71d-a1c6-45df-9d9c-f33657e5c832" />

PC after
<img width="1920" height="911" alt="「得られた結果」の列が横長で適切な表示になっている、PC表示時のテーブル。左右がメインコンテンツからはみ出している。" src="https://github.com/user-attachments/assets/98c8ec09-32a7-4295-b4b9-98efa998e9fc" />

sp before
<img width="419" height="824" alt="「得られた結果」の列が長細くなっている、sp表示時のテーブル" src="https://github.com/user-attachments/assets/80757f7f-ca5c-4198-ad8d-82ab85d27a5d" />

sp after
<img width="419" height="824" alt="「得られた結果」の列が横長で適切な表示になっている、sp表示時のテーブル" src="https://github.com/user-attachments/assets/9940eb3f-e740-41a1-a8a1-4e507707a08b" />

PC 代替案
<img width="1920" height="911" alt="「得られた結果」の列が横長で適切な表示になっている、PC表示時のテーブル。右側のみメインコンテンツからはみ出している。" src="https://github.com/user-attachments/assets/d442dad7-a393-4a57-aab6-c83f9fab48b0" />
