### PR TITLE
chore: add GitHub Pages deploy workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,56 @@
+name: github-pages
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.12'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build (GitHub Pages)
+        env:
+          NODE_ENV: production
+          ASTRO_BASE: /as_info/
+          ASTRO_SITE: https://waic.github.io
+        run: npm run build
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./docs
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -3,15 +3,20 @@ import { defineConfig } from 'astro/config';
 import react from '@astrojs/react';
 
 // Next.js実装と同じ: App Engineではbase: '/'、本番ではbase: '/docs/as/info/'
+// GitHub Pagesなどでは ASTRO_BASE / ASTRO_SITE で上書き可能にする
 const isAppEngine = !!process.env.GAE_APPLICATION;
 const isProd = process.env.NODE_ENV === 'production';
-const base = isAppEngine ? '/' : (isProd ? '/docs/as/info/' : '');
+const defaultBase = isAppEngine ? '/' : (isProd ? '/docs/as/info/' : '');
+const base = process.env.ASTRO_BASE ?? defaultBase;
+
+const defaultSite = 'https://waic.jp';
+const site = process.env.ASTRO_SITE ?? defaultSite;
 
 // https://astro.build/config
 export default defineConfig({
   output: 'static',
   integrations: [react()],
-  site: 'https://waic.jp',
+  site,
   base: base,
   outDir: './docs',
   build: {

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -2,8 +2,10 @@
 import { defineConfig } from 'astro/config';
 import react from '@astrojs/react';
 
-// Next.js実装と同じ: App Engineではbase: '/'、本番ではbase: '/docs/as/info/'
-// GitHub Pagesなどでは ASTRO_BASE / ASTRO_SITE で上書き可能にする
+// デプロイ先ごとに base を切り替える
+// - App Engine: base = '/'（GAE_APPLICATION がある）
+// - 本番(既存の静的ホスティング想定): base = '/docs/as/info/'（NODE_ENV=production）
+// - GitHub Pages: base/site を ASTRO_BASE / ASTRO_SITE で明示的に上書き
 const isAppEngine = !!process.env.GAE_APPLICATION;
 const isProd = process.env.NODE_ENV === 'production';
 const defaultBase = isAppEngine ? '/' : (isProd ? '/docs/as/info/' : '');


### PR DESCRIPTION
以下の3種類に対応します。

- 静的ホスティング用のビルド (npm run build)
- App Engine (pull request)
- GitHub Pages (master更新)
