### PR TITLE
fix(ci): set explicit workflow permissions for GAE deploy

### DIFF
--- a/.github/workflows/appengine-deploy.yml
+++ b/.github/workflows/appengine-deploy.yml
@@ -4,6 +4,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     name: GAE deploy


### PR DESCRIPTION
## Summary

- Code scanning alert [#1](https://github.com/waic/as_info/security/code-scanning/1)（`actions/missing-workflow-permissions`）を解消
- `.github/workflows/appengine-deploy.yml` に `permissions: contents: read` を追加し、`GITHUB_TOKEN` を読み取り限定に明示

## 背景

`deploy` job は `actions/checkout` によるコード取得が主な `GITHUB_TOKEN` 利用で、GCP 認証は `secrets.GCP_SA_KEY` 経由のため `id-token: write` は不要です。

## Test plan

- [ ] CI が通ること
- [ ] Code scanning alert #1 が close されること